### PR TITLE
Git url was telling me I didn't have permission

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "underscore": "~1.4.4",
     "async": "~0.1.22",
     "request": "~2.16",
-    "rendr": "git+ssh://git@github.com:airbnb/rendr.git#2c9aa6ed8d4f743a066cab2c3c64cfa0ec22e723",
+    "rendr": "git://github.com/airbnb/rendr.git#2c9aa6ed8d4f743a066cab2c3c64cfa0ec22e723",
     "debug": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi,

I changed the git url for rendr because it kept complaining that I didn't have permission to access that repo when doing npm install.

Thanks,

Manuel
