### PR TITLE
Adding `node` in front of the nodemon script fixes `grunt server` on Windows

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,7 +11,7 @@ module.exports = function(grunt) {
 
     bgShell: {
       runNode: {
-        cmd: './node_modules/nodemon/nodemon.js index.js',
+        cmd: 'node ./node_modules/nodemon/nodemon.js index.js',
         bg: true
       }
     },


### PR DESCRIPTION
Should fix #19
