### PR TITLE
Line up rendr-handlebars stitch paths

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,7 @@ var path = require('path');
 
 var stylesheetsDir = 'assets/stylesheets';
 var rendrDir = 'node_modules/rendr';
+var rendrHandlebarsDir = 'node_modules/rendr-handlebars';
 var rendrModulesDir = rendrDir + '/node_modules';
 
 module.exports = function(grunt) {
@@ -81,13 +82,14 @@ module.exports = function(grunt) {
           npmDependencies: {
             underscore: '../rendr/node_modules/underscore/underscore.js',
             backbone: '../rendr/node_modules/backbone/backbone.js',
-            handlebars: '../rendr/node_modules/rendr-handlebars/node_modules/handlebars/dist/handlebars.runtime.js',
+            handlebars: '../rendr-handlebars/node_modules/handlebars/dist/handlebars.runtime.js',
             async: '../rendr/node_modules/async/lib/async.js',
-            'rendr-handlebars': 'index.js'
           },
           aliases: [
             {from: rendrDir + '/client', to: 'rendr/client'},
-            {from: rendrDir + '/shared', to: 'rendr/shared'}
+            {from: rendrDir + '/shared', to: 'rendr/shared'},
+            {from: rendrHandlebarsDir, to: 'rendr-handlebars'},
+            {from: rendrHandlebarsDir + '/shared', to: 'rendr-handlebars/shared'}
           ]
         },
         files: [{
@@ -95,7 +97,9 @@ module.exports = function(grunt) {
           src: [
             'app/**/*.js',
             rendrDir + '/client/**/*.js',
-            rendrDir + '/shared/**/*.js'
+            rendrDir + '/shared/**/*.js',
+            rendrHandlebarsDir + '/index.js',
+            rendrHandlebarsDir + '/shared/*.js'
           ]
         }]
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "underscore": "~1.4.4",
     "async": "~0.1.22",
     "request": "~2.16",
-    "rendr": "0.4.6-rc.1",
+    "rendr": "git://github.com/airbnb/rendr.git#template-adapter",
     "rendr-handlebars": "git://github.com/airbnb/rendr-handlebars.git",
     "debug": "*"
   },


### PR DESCRIPTION
Continues [rendr#56](https://github.com/airbnb/rendr/pull/56) with just enough to get rendr-handlebars functional without Browserify.  Adds a little overhead to project's Gruntfiles, but this is being addressed separately in [rendr#35](https://github.com/airbnb/rendr/issues/35).
