### PR TITLE
replace grunt-bg-shell with grunt.util.spawn

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -108,12 +108,13 @@ module.exports = function(grunt) {
     var done = this.async(),
       child = grunt.util.spawn({
         cmd: 'node',
-        args: ['./node_modules/nodemon/nodemon.js', '--debug', 'index.js']
+        args: ['./node_modules/nodemon/nodemon.js', '--debug', 'index.js'],
+        opts: {
+          stdio: 'inherit'
+        }
       }, function () {
         done(new Error('Nodemon quit.'));
       });
-    child.stdout.pipe(process.stdout);
-    child.stderr.pipe(process.stderr);
   });
 
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,13 +10,6 @@ module.exports = function(grunt) {
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
 
-    bgShell: {
-      runNode: {
-        cmd: 'node ./node_modules/nodemon/nodemon.js index.js',
-        bg: true
-      }
-    },
-
     stylus: {
       compile: {
         options: {
@@ -109,13 +102,25 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-stylus');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-handlebars');
-  grunt.loadNpmTasks('grunt-bg-shell');
   grunt.loadNpmTasks('grunt-rendr-stitch');
+
+  grunt.registerTask('runNode', function () {
+    var done = this.async(),
+      child = grunt.util.spawn({
+        cmd: 'node',
+        args: ['./node_modules/nodemon/nodemon.js', '--debug', 'index.js']
+      }, function () {
+        done(new Error('Nodemon quit.'));
+      });
+    child.stdout.pipe(process.stdout);
+    child.stderr.pipe(process.stderr);
+  });
+
 
   grunt.registerTask('compile', ['handlebars', 'rendr_stitch', 'stylus']);
 
   // Run the server and watch for file changes
-  grunt.registerTask('server', ['bgShell:runNode', 'compile', 'watch']);
+  grunt.registerTask('server', ['runNode', 'compile', 'watch']);
 
   // Default task(s).
   grunt.registerTask('default', ['compile']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -105,16 +105,15 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-rendr-stitch');
 
   grunt.registerTask('runNode', function () {
-    var done = this.async(),
-      child = grunt.util.spawn({
-        cmd: 'node',
-        args: ['./node_modules/nodemon/nodemon.js', '--debug', 'index.js'],
-        opts: {
-          stdio: 'inherit'
-        }
-      }, function () {
-        done(new Error('Nodemon quit.'));
-      });
+    grunt.util.spawn({
+      cmd: 'node',
+      args: ['./node_modules/nodemon/nodemon.js', '--debug', 'index.js'],
+      opts: {
+        stdio: 'inherit'
+      }
+    }, function () {
+      grunt.fail.fatal(new Error("nodemon quit"));
+    });
   });
 
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "grunt-contrib-handlebars": "git://github.com/spikebrehm/grunt-contrib-handlebars#a4ae75750efeb23bf8ca9c61d9cf7569d40879fa",
     "grunt-rendr-stitch": "~0.0.6",
     "grunt-contrib-watch": "~0.3.1",
-    "grunt-bg-shell": "~2.0.1",
     "nodemon": "~0.7.6",
     "mocha": "~1.9.0",
     "should": "~1.2.2"


### PR DESCRIPTION
with grunt-bg-shell the child stdout of the child process would be buffered
until the buffer is full and node would then kill the process
