### PR TITLE
enable functional testing of the express app

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,4 +68,9 @@ function start() {
  */
 initMiddleware();
 initServer();
-start();
+// Only start server if this script is executed, not if it's require()'d
+if (require.main === module) {
+  start();
+}
+
+exports.app = app;


### PR DESCRIPTION
- don't start server if index.js is require()'d
- expose the express app object

this allows to require() the index.js file to run tests against it on ephemeral
ports (as done by supertest and chai-http)
