### PR TITLE
Support Internet Explorer (avoid setting __proto__)

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -4,7 +4,7 @@ var Router = module.exports = function Router(options) {
   BaseClientRouter.call(this, options);
 };
 
-Router.prototype.__proto__ = BaseClientRouter.prototype;
+Router.prototype = BaseClientRouter.prototype;
 
 Router.prototype.postInitialize = function() {
   this.on('action:start', this.trackImpression, this);


### PR DESCRIPTION
By setting Router.prototype instead of Router.prototype.**proto**, the example app now works in IE9 and IE10.

A mutable **proto** won't be supported by Internet Explorer until the release of IE11, and is not a part of the ES5 standard.
